### PR TITLE
Add prettier and a GitHub action to run the linter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,53 +1,33 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "es6": true
+    env: {
+        browser: true,
+        es6: true,
     },
-    "extends": [
-        "eslint:recommended",
-        "plugin:react/recommended",
-        "plugin:@typescript-eslint/eslint-recommended"
+    extends: [
+        'eslint:recommended',
+        'plugin:react/recommended',
+        'plugin:@typescript-eslint/eslint-recommended',
+        'plugin:prettier/recommended',
     ],
-    "globals": {
-        "Atomics": "readonly",
-        "SharedArrayBuffer": "readonly"
+    globals: {
+        Atomics: 'readonly',
+        SharedArrayBuffer: 'readonly',
     },
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaFeatures": {
-            "jsx": true
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+        ecmaFeatures: {
+            jsx: true,
         },
-        "ecmaVersion": 2018,
-        "sourceType": "module"
+        ecmaVersion: 2018,
+        sourceType: 'module',
     },
-    "plugins": [
-        "react",
-        "@typescript-eslint"
-    ],
-    "rules": {
-        "indent": [
-            "error",
-            4
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "double"
-        ],
-        "semi": [
-            "error",
-            "always"
-        ],
-        "react/prop-types": [
-            0
-        ]
+    plugins: ['react', '@typescript-eslint'],
+    rules: {
+        'react/prop-types': [0],
     },
-    "settings": {
-        "react": {
-            "version": "detect"
-        }
-    }
-}
+    settings: {
+        react: {
+            version: 'detect',
+        },
+    },
+};

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,29 @@
+# This workflow will do a clean install of node dependencies, check that the typescript compiles and that run the linter.
+# It will run these checks on both node 10 and node 12.
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Lint using Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm run lint

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+    "semi": true,
+    "trailingComma": "all"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4007,6 +4007,24 @@
                 }
             }
         },
+        "eslint-config-prettier": {
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
+            "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
+            "dev": true,
+            "requires": {
+                "get-stdin": "^6.0.0"
+            }
+        },
+        "eslint-plugin-prettier": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz",
+            "integrity": "sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==",
+            "dev": true,
+            "requires": {
+                "prettier-linter-helpers": "^1.0.0"
+            }
+        },
         "eslint-plugin-react": {
             "version": "7.19.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz",
@@ -4466,6 +4484,12 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
             "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+            "dev": true
+        },
+        "fast-diff": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+            "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
             "dev": true
         },
         "fast-glob": {
@@ -5393,6 +5417,12 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true
+        },
+        "get-stdin": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+            "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
             "dev": true
         },
         "get-stream": {
@@ -8508,6 +8538,15 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
             "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
             "dev": true
+        },
+        "prettier-linter-helpers": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+            "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+            "dev": true,
+            "requires": {
+                "fast-diff": "^1.1.2"
+            }
         },
         "pretty-hrtime": {
             "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
         "axios": "^0.19",
         "cross-env": "^7.0.1",
         "eslint": "^6.8.0",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-plugin-prettier": "^3.1.3",
         "eslint-plugin-react": "^7.19.0",
         "eslint-plugin-react-hooks": "^2.5.1",
         "laravel-mix": "^5.0.1",

--- a/resources/js/Atoms/AuthLayout.tsx
+++ b/resources/js/Atoms/AuthLayout.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
 interface Props {
-  children: React.ReactNode;
-  heading: string;
-  message: string;
+    children: React.ReactNode;
+    heading: string;
+    message: string;
 }
 
 export default function AuthLayout({ children, heading, message }: Props) {
@@ -11,7 +11,7 @@ export default function AuthLayout({ children, heading, message }: Props) {
         <>
             <div className="box-border p-4 border-4 border-gray-400 bg-gray-200">
                 <h1 className="text-2xl text-gray-800 text-center font-extrabold">
-          CodeHub Mentorship App
+                    CodeHub Mentorship App
                 </h1>
             </div>
             <div className="min-h-screen bg-gray-50 flex flex-col py-12 sm:px-6 lg:px-8">

--- a/resources/js/Atoms/Button.tsx
+++ b/resources/js/Atoms/Button.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
 interface Props {
-  children: React.ReactChildren;
-  size: "small" | "medium" | "large";
+    children: React.ReactChildren;
+    size: "small" | "medium" | "large";
 }
 
 export default function Button({ children, size }: Props) {
@@ -12,16 +12,16 @@ export default function Button({ children, size }: Props) {
 
     let styling;
     switch (size) {
-    case "small":
-        styling =
-        "inline-flex items-center px-4 py-2 border border-transparent text-sm leading-5 font-small rounded-md text-white bg-red-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition ease-in-out duration-150";
-        break;
-    case "medium":
-        styling =
-        "inline-flex items-center px-8 py-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-blue-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition ease-in-out duration-150";
-        break;
-    default:
-        styling = "";
+        case "small":
+            styling =
+                "inline-flex items-center px-4 py-2 border border-transparent text-sm leading-5 font-small rounded-md text-white bg-red-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition ease-in-out duration-150";
+            break;
+        case "medium":
+            styling =
+                "inline-flex items-center px-8 py-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-blue-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition ease-in-out duration-150";
+            break;
+        default:
+            styling = "";
     }
 
     return (

--- a/resources/js/Atoms/FormLayout.tsx
+++ b/resources/js/Atoms/FormLayout.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
 interface Props {
-  children: React.ReactNode;
-  heading: string;
-  message: string;
+    children: React.ReactNode;
+    heading: string;
+    message: string;
 }
 
 export default function FormLayout({ children, heading, message }: Props) {
@@ -11,7 +11,7 @@ export default function FormLayout({ children, heading, message }: Props) {
         <>
             <div className="box-border p-4 border-4 border-gray-400 bg-gray-200">
                 <h1 className="text-2xl text-gray-800 text-center font-extrabold">
-          CodeHub Mentorship App
+                    CodeHub Mentorship App
                 </h1>
             </div>
             <div className="min-h-screen bg-gray-50  flex flex-col py-12 sm:px-6 lg:px-20">

--- a/resources/js/Atoms/Textarea.tsx
+++ b/resources/js/Atoms/Textarea.tsx
@@ -1,33 +1,36 @@
 import * as React from "react";
 
 interface iFieldProps {
-  name: string;
-  label?: string;
-  value?: string;
-  helpText?: string;
-  onChange: (e: React.FormEvent<HTMLTextAreaElement>) => void;
+    name: string;
+    label?: string;
+    value?: string;
+    helpText?: string;
+    onChange: (e: React.FormEvent<HTMLTextAreaElement>) => void;
 }
 
 export const Textarea: React.FC<iFieldProps> = ({
-  name,
-  label,
-  value,
-  onChange,
-  helpText,
+    name,
+    label,
+    value,
+    onChange,
+    helpText,
 }) => {
-  return (
-    <div>
-      <label htmlFor={name} className="block text-sm font-medium text-gray-700">
-        {label}
-      </label>
-      <textarea
-        id={name}
-        name={name}
-        value={value}
-        className="form-input block bg-gray-100 w-full pl-7 pr-12 sm:text-sm sm:leading-5"
-        onChange={onChange}
-        placeholder={helpText}
-      />
-    </div>
-  );
+    return (
+        <div>
+            <label
+                htmlFor={name}
+                className="block text-sm font-medium text-gray-700"
+            >
+                {label}
+            </label>
+            <textarea
+                id={name}
+                name={name}
+                value={value}
+                className="form-input block bg-gray-100 w-full pl-7 pr-12 sm:text-sm sm:leading-5"
+                onChange={onChange}
+                placeholder={helpText}
+            />
+        </div>
+    );
 };

--- a/resources/js/Molecules/Card.tsx
+++ b/resources/js/Molecules/Card.tsx
@@ -1,18 +1,27 @@
 import React from "react";
 
 interface IProps {
-    heading?: String,
-    hasPadding?: Boolean
+    heading?: String;
+    hasPadding?: Boolean;
 }
-
 
 const Card: React.FC<IProps> = ({ heading, hasPadding }) => {
     return (
         <section>
             <div className="bg-white shadow overflow-hidden sm:rounded-lg">
-                <div className={(hasPadding) ? "px-4 py-5 border-b border-gray-200 sm:px-6" : "border-b border-gray-200 sm:px-6"}>
+                <div
+                    className={
+                        hasPadding
+                            ? "px-4 py-5 border-b border-gray-200 sm:px-6"
+                            : "border-b border-gray-200 sm:px-6"
+                    }
+                >
                     <div className="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-                        {heading ?? (<h3 className="text-lg leading-6 font-medium text-gray-900">{heading}</h3>)}
+                        {heading ?? (
+                            <h3 className="text-lg leading-6 font-medium text-gray-900">
+                                {heading}
+                            </h3>
+                        )}
                         <dd className="text-sm leading-5 font-medium text-gray-500">
                             A section
                         </dd>

--- a/resources/js/Molecules/FormChoiceField.tsx
+++ b/resources/js/Molecules/FormChoiceField.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 
 interface choice {
-  label: string;
-  helptext: string;
-  value: string;
+    label: string;
+    helptext: string;
+    value: string;
 }
 interface IProps {
-  type: "checkbox" | "radio";
-  label: string;
-  selected: string;
-  choices: choice[];
-  helpText?: string;
-  onChange: (e: React.FormEvent<HTMLInputElement>) => void;
-  name: string;
+    type: "checkbox" | "radio";
+    label: string;
+    selected: string;
+    choices: choice[];
+    helpText?: string;
+    onChange: (e: React.FormEvent<HTMLInputElement>) => void;
+    name: string;
 }
 const FormChoiceField: React.FC<IProps> = ({
     type,
@@ -28,30 +28,32 @@ const FormChoiceField: React.FC<IProps> = ({
             <label className="block text-sm leading-5 font-medium text-gray-700">
                 {label}
             </label>
-            <p className="text-sm leading-5 font-medium text-gray-400">{helpText}</p>
+            <p className="text-sm leading-5 font-medium text-gray-400">
+                {helpText}
+            </p>
             {choices &&
-        choices.map((choice, index) => (
-            <div key={index} className="mt-4 flex items-center">
-                <input
-                    type={type}
-                    id={choice.value}
-                    name={name}
-                    value={choice.value}
-                    checked={
-                        type === "radio"
-                            ? selected === choice.value
-                            : selected.indexOf(choice.value) > -1
-                    }
-                    className={`form-${type} h-4 w-4 text-indigo-600 bg-gray-100 transition duration-150 ease-in-out`}
-                    onChange={onChange}
-                />
-                <label htmlFor={choice.value} className="ml-3">
-                    <span className="block text-sm leading-5 font-medium text-gray-700">
-                        {choice.label}
-                    </span>
-                </label>
-            </div>
-        ))}
+                choices.map((choice, index) => (
+                    <div key={index} className="mt-4 flex items-center">
+                        <input
+                            type={type}
+                            id={choice.value}
+                            name={name}
+                            value={choice.value}
+                            checked={
+                                type === "radio"
+                                    ? selected === choice.value
+                                    : selected.indexOf(choice.value) > -1
+                            }
+                            className={`form-${type} h-4 w-4 text-indigo-600 bg-gray-100 transition duration-150 ease-in-out`}
+                            onChange={onChange}
+                        />
+                        <label htmlFor={choice.value} className="ml-3">
+                            <span className="block text-sm leading-5 font-medium text-gray-700">
+                                {choice.label}
+                            </span>
+                        </label>
+                    </div>
+                ))}
         </div>
     );
 };

--- a/resources/js/Molecules/FormTextInput.tsx
+++ b/resources/js/Molecules/FormTextInput.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 
 interface IProps {
-  type:string;  
-  name: string;
-  label?: string;
-  value?: string;
-  helpText?: string;
-  onChange: (e: React.FormEvent<HTMLInputElement>) => void;
+    type: string;
+    name: string;
+    label?: string;
+    value?: string;
+    helpText?: string;
+    onChange: (e: React.FormEvent<HTMLInputElement>) => void;
 }
 
 const FormTextInput: React.FC<IProps> = ({

--- a/resources/js/Organisms/Form.tsx
+++ b/resources/js/Organisms/Form.tsx
@@ -1,42 +1,47 @@
 import React, { useState, useEffect } from "react";
 
 interface IFormProps {
-  /* The http path that the form will be posted to */
-  action: string;
-  initialValues: IValues;
-  button:string;
-  /* A prop which allows content to be injected */
-  render: (
-    val: IValues,
-    handleChange: (
-      e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>
-    ) => void,
-    errors: IErrors
-  ) => React.ReactNode;
+    /* The http path that the form will be posted to */
+    action: string;
+    initialValues: IValues;
+    button: string;
+    /* A prop which allows content to be injected */
+    render: (
+        val: IValues,
+        handleChange: (
+            e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
+        ) => void,
+        errors: IErrors,
+    ) => React.ReactNode;
 }
 
 export interface IValues {
-  /* Key value pairs for all the field values with key being the field name */
-  [key: string]: any;
+    /* Key value pairs for all the field values with key being the field name */
+    [key: string]: any;
 }
 
 export interface IErrors {
-  /* The validation error messages for each field (key is the field name */
-  [key: string]: string;
+    /* The validation error messages for each field (key is the field name */
+    [key: string]: string;
 }
 
 export interface IFormState {
-  /* The field values */
-  values: IValues;
+    /* The field values */
+    values: IValues;
 
-  /* The field validation error messages */
-  errors: IErrors;
+    /* The field validation error messages */
+    errors: IErrors;
 
-  /* Whether the form has been successfully submitted */
-  submitSuccess?: boolean;
+    /* Whether the form has been successfully submitted */
+    submitSuccess?: boolean;
 }
 
-const Form: React.FC<IFormProps> = ({ action, initialValues, button, render }) => {
+const Form: React.FC<IFormProps> = ({
+    action,
+    initialValues,
+    button,
+    render,
+}) => {
     const [errors, setErrors] = useState<IErrors>({});
     const [values, setValues] = useState<IValues>(initialValues);
     const [submitSuccess, setSuccess] = useState(undefined);
@@ -56,7 +61,7 @@ const Form: React.FC<IFormProps> = ({ action, initialValues, button, render }) =
         if (type === "checkbox") {
             let newSelection: any[];
             if (values[name].indexOf(value) > -1) {
-                newSelection = values[name].filter((s) => s !== value);
+                newSelection = values[name].filter(s => s !== value);
             } else {
                 newSelection = [...values[name], value];
             }
@@ -73,19 +78,18 @@ const Form: React.FC<IFormProps> = ({ action, initialValues, button, render }) =
     useEffect(() => {
         if (haveErrors(errors)) {
             validateForm();
-        }}, [values]  
-    );
-    
+        }
+    }, [values]);
 
     const validateForm = (): boolean => {
         let newErrors: IErrors = errors;
         let formisValid: boolean = true;
         newErrors.fullname = "";
         newErrors.email = "";
-        newErrors.password ='';
-        newErrors.confirmpwd ='';
+        newErrors.password = "";
+        newErrors.confirmpwd = "";
 
-        if(values.hasOwnProperty("fullname")){
+        if (Object.prototype.hasOwnProperty.call(values, "fullname")) {
             if (!values["fullname"] || values["fullname"].trim().length === 0) {
                 newErrors.fullname = "Please enter your fullname";
                 formisValid = false;
@@ -98,38 +102,38 @@ const Form: React.FC<IFormProps> = ({ action, initialValues, button, render }) =
             formisValid = false;
         }
 
-        if(values.hasOwnProperty("confirmpwd")) {  
-            if (values["password"].trim().length<8) {
-                errors.password = 'password length should be atleast 8 characters.';
+        if (Object.prototype.hasOwnProperty.call(values, "confirmpwd")) {
+            if (values["password"].trim().length < 8) {
+                errors.password =
+                    "password length should be atleast 8 characters.";
                 formisValid = false;
             }
         }
 
-        if(values.hasOwnProperty("confirmpwd")) {  
+        if (Object.prototype.hasOwnProperty.call(values, "confirmpwd")) {
             if (values["password"] !== values["confirmpwd"]) {
-                errors.confirmpwd = 'Passwords do not match.';
+                errors.confirmpwd = "Passwords do not match.";
                 formisValid = false;
-            }     
-        }  
-
+            }
+        }
 
         setErrors({
             ...errors,
-            fullname:newErrors.fullname,
-            email:newErrors.email,
-            password:newErrors.password,
-            confirmpwd:newErrors.confirmpwd
+            fullname: newErrors.fullname,
+            email: newErrors.email,
+            password: newErrors.password,
+            confirmpwd: newErrors.confirmpwd,
         });
         return formisValid;
     };
 
     const submitForm = async (): Promise<boolean> => {
-    // TODO - submit the form
+        // TODO - submit the form
         return true;
     };
 
     const handleSubmit = async (
-        e: React.FormEvent<HTMLFormElement>
+        e: React.FormEvent<HTMLFormElement>,
     ): Promise<void> => {
         e.preventDefault();
         console.log(values);
@@ -150,32 +154,37 @@ const Form: React.FC<IFormProps> = ({ action, initialValues, button, render }) =
         assigned to it */}
                 {render(
                     values,
-                    (e) => updateState(e.target as HTMLInputElement),
-                    errors
+                    e => updateState(e.target as HTMLInputElement),
+                    errors,
                 )}
 
                 <div className="form-group">
                     <button
                         type="submit"
-                        className={button!=="Login"? "block mx-auto px-4 py-2 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition ease-in-out duration-150":"w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition duration-150 ease-in-out"}
+                        className={
+                            button !== "Login"
+                                ? "block mx-auto px-4 py-2 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition ease-in-out duration-150"
+                                : "w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition duration-150 ease-in-out"
+                        }
                         disabled={haveErrors(errors)}
                     >
-            {button}
+                        {button}
                     </button>
                 </div>
                 {submitSuccess && (
                     <div className="alert alert-info" role="alert">
-            The form was successfully submitted!
+                        The form was successfully submitted!
                     </div>
                 )}
                 {submitSuccess === false && !haveErrors(errors) && (
                     <div className="alert alert-danger" role="alert">
-            Sorry, an unexpected error has occurred
+                        Sorry, an unexpected error has occurred
                     </div>
                 )}
                 {submitSuccess === false && haveErrors(errors) && (
                     <div className="alert alert-danger" role="alert">
-            Sorry, the form is invalid. Please review, adjust and try again
+                        Sorry, the form is invalid. Please review, adjust and
+                        try again
                     </div>
                 )}
             </div>

--- a/resources/js/Organisms/SampleForm.tsx
+++ b/resources/js/Organisms/SampleForm.tsx
@@ -4,45 +4,45 @@ import FormTextInput from "@/Molecules/FormTextInput";
 import FormChoiceField from "@/Molecules/FormChoiceField";
 
 const SampleForm: React.FC = () => {
-	return (
-		<Form
-			action=""
-			initialValues={{ fullname: "", contact: "" }}
-			button="Submit"
-			render={(values, handleChange) => (
-				<React.Fragment>
-					<FormTextInput
-						type="text"
-						name="fullname"
-						label="Full name"
-						value={values["fullname"]}
-						helpText="Please enter your full name"
-						onChange={handleChange}
-					/>
-					<FormChoiceField
-						type="radio"
-						label="Contact"
-						selected={values["contact"]}
-						choices={[
-							{
-								label: "email",
-								helptext: "Email",
-								value: "email",
-							},
-							{
-								label: "phone",
-								helptext: "Phone",
-								value: "phone",
-							},
-						]}
-						helpText="Prefered way to contact"
-						onChange={handleChange}
-						name="contact"
-					/>
-				</React.Fragment>
-			)}
-		/>
-	);
+    return (
+        <Form
+            action=""
+            initialValues={{ fullname: "", contact: "" }}
+            button="Submit"
+            render={(values, handleChange) => (
+                <React.Fragment>
+                    <FormTextInput
+                        type="text"
+                        name="fullname"
+                        label="Full name"
+                        value={values["fullname"]}
+                        helpText="Please enter your full name"
+                        onChange={handleChange}
+                    />
+                    <FormChoiceField
+                        type="radio"
+                        label="Contact"
+                        selected={values["contact"]}
+                        choices={[
+                            {
+                                label: "email",
+                                helptext: "Email",
+                                value: "email",
+                            },
+                            {
+                                label: "phone",
+                                helptext: "Phone",
+                                value: "phone",
+                            },
+                        ]}
+                        helpText="Prefered way to contact"
+                        onChange={handleChange}
+                        name="contact"
+                    />
+                </React.Fragment>
+            )}
+        />
+    );
 };
 
 export default SampleForm;

--- a/resources/js/Pages/Login.tsx
+++ b/resources/js/Pages/Login.tsx
@@ -4,64 +4,67 @@ import FormTextInput from "@/Molecules/FormTextInput";
 import AuthLayout from "@/Atoms/AuthLayout";
 import FormChoiceField from "@/Molecules/FormChoiceField";
 
-
 const LoginForm: React.FC = () => {
-	return (
-		<AuthLayout heading="Login" message="Log into your account">
-			<Form
-				action=""
-				initialValues={{ email: "", password: "",rememberme:[] }}
-				button="Login"
-				render={(values, handleChange) => (
-					<React.Fragment>
-						<FormTextInput
-							type="email"
-							name="email"
-							label="Email address"
-							value={values["email"]}
-							helpText=""
-							onChange={handleChange}
-						/>
-						<div className="block text-sm font-medium text-red-500 pb-5"></div>
-						<FormTextInput
-							type="password"
-							name="password"
-							label="Password"
-							value={values["password"]}
-							helpText=""
-							onChange={handleChange}
-						/>
-						<div className="mt-6 flex items-center justify-between">
-							<div className="flex items-center">	
-								<FormChoiceField
-									type="checkbox"
-									label=""
-									selected={values["rememberme"]}
-									choices={[
-										{
-											label: "Remember me",
-											helptext: "",
-											value: "yes",
-										}
-									]}
-									onChange={handleChange}
-									name="rememberme"
-								/>
-							</div>
-							<div className="text-sm leading-5">
-								<a href="#" className="font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:underline transition ease-in-out duration-150">
-									Forgot your password?
-								</a>
-							</div>
-						</div>
-						<div className="block text-sm font-medium text-red-500 pb-5"></div>		
-					</React.Fragment>
-				)}
-			/>
-			<div className="font-medium text-indigo-600 pt-5 hover:text-indigo-500 focus:outline-none focus:underline transition ease-in-out duration-150"><a href="/register">Register</a></div>
-				
-		</AuthLayout>
-	);
+    return (
+        <AuthLayout heading="Login" message="Log into your account">
+            <Form
+                action=""
+                initialValues={{ email: "", password: "", rememberme: [] }}
+                button="Login"
+                render={(values, handleChange) => (
+                    <React.Fragment>
+                        <FormTextInput
+                            type="email"
+                            name="email"
+                            label="Email address"
+                            value={values["email"]}
+                            helpText=""
+                            onChange={handleChange}
+                        />
+                        <div className="block text-sm font-medium text-red-500 pb-5"></div>
+                        <FormTextInput
+                            type="password"
+                            name="password"
+                            label="Password"
+                            value={values["password"]}
+                            helpText=""
+                            onChange={handleChange}
+                        />
+                        <div className="mt-6 flex items-center justify-between">
+                            <div className="flex items-center">
+                                <FormChoiceField
+                                    type="checkbox"
+                                    label=""
+                                    selected={values["rememberme"]}
+                                    choices={[
+                                        {
+                                            label: "Remember me",
+                                            helptext: "",
+                                            value: "yes",
+                                        },
+                                    ]}
+                                    onChange={handleChange}
+                                    name="rememberme"
+                                />
+                            </div>
+                            <div className="text-sm leading-5">
+                                <a
+                                    href="#"
+                                    className="font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:underline transition ease-in-out duration-150"
+                                >
+                                    Forgot your password?
+                                </a>
+                            </div>
+                        </div>
+                        <div className="block text-sm font-medium text-red-500 pb-5"></div>
+                    </React.Fragment>
+                )}
+            />
+            <div className="font-medium text-indigo-600 pt-5 hover:text-indigo-500 focus:outline-none focus:underline transition ease-in-out duration-150">
+                <a href="/register">Register</a>
+            </div>
+        </AuthLayout>
+    );
 };
 
 export default LoginForm;

--- a/resources/js/Pages/Register.tsx
+++ b/resources/js/Pages/Register.tsx
@@ -3,65 +3,77 @@ import Form from "@/Organisms/Form";
 import FormTextInput from "@/Molecules/FormTextInput";
 import AuthLayout from "@/Atoms/AuthLayout";
 
-
 const RegisterForm: React.FC = () => {
-	return (
-		<AuthLayout heading="Register" message="Please register to create a profile">
-			<Form
-				action=""
-				initialValues={{ fullname:"",email: "", password: "",confirmpwd:"" }}
-				button="Register"
-				render={(values, handleChange,errors) => (
-					<React.Fragment>
-						<FormTextInput
-							type = "text"
-							name ="fullname"
-							label="Full Name"
-							value={values["fullname"]}
-							helpText=""
-							onChange={handleChange}
-						/>
-						<div className="block text-sm font-medium text-red-500 pb-5">{errors["fullname"]}</div>
-						<FormTextInput
-							type="email"
-							name="email"
-							label="Email address"
-							value={values["email"]}
-							helpText=""
-							onChange={handleChange}
-						/>
-						<div className="block text-sm font-medium text-red-500 pb-5">{errors["email"]}</div>
-						<FormTextInput
-						    type="password"
-							name="password"
-							label="Password"
-							value={values["password"]}
-							helpText=""
-							onChange={handleChange}
-						/>
-		
-						<div className="block text-sm font-medium text-red-500 pb-5">{errors["password"]}</div>
-						<FormTextInput
-							type="password"
-							name="confirmpwd"
-							label="Confirm Password"
-							value={values["confirmpwd"]}
-							helpText=""
-							onChange={handleChange}
-						/>
-		
-						<div className="block text-sm font-medium text-red-500 pb-5">{errors["confirmpwd"]}</div>	
-				
-					</React.Fragment>
-				)}
-			/>
-			<div className="font-medium text-indigo-600 pt-5 hover:text-indigo-500 focus:outline-none focus:underline transition ease-in-out duration-150">
-				<a href="/login">Login</a>
-			</div>
-		
-		</AuthLayout>
-	);
+    return (
+        <AuthLayout
+            heading="Register"
+            message="Please register to create a profile"
+        >
+            <Form
+                action=""
+                initialValues={{
+                    fullname: "",
+                    email: "",
+                    password: "",
+                    confirmpwd: "",
+                }}
+                button="Register"
+                render={(values, handleChange, errors) => (
+                    <React.Fragment>
+                        <FormTextInput
+                            type="text"
+                            name="fullname"
+                            label="Full Name"
+                            value={values["fullname"]}
+                            helpText=""
+                            onChange={handleChange}
+                        />
+                        <div className="block text-sm font-medium text-red-500 pb-5">
+                            {errors["fullname"]}
+                        </div>
+                        <FormTextInput
+                            type="email"
+                            name="email"
+                            label="Email address"
+                            value={values["email"]}
+                            helpText=""
+                            onChange={handleChange}
+                        />
+                        <div className="block text-sm font-medium text-red-500 pb-5">
+                            {errors["email"]}
+                        </div>
+                        <FormTextInput
+                            type="password"
+                            name="password"
+                            label="Password"
+                            value={values["password"]}
+                            helpText=""
+                            onChange={handleChange}
+                        />
+
+                        <div className="block text-sm font-medium text-red-500 pb-5">
+                            {errors["password"]}
+                        </div>
+                        <FormTextInput
+                            type="password"
+                            name="confirmpwd"
+                            label="Confirm Password"
+                            value={values["confirmpwd"]}
+                            helpText=""
+                            onChange={handleChange}
+                        />
+
+                        <div className="block text-sm font-medium text-red-500 pb-5">
+                            {errors["confirmpwd"]}
+                        </div>
+                    </React.Fragment>
+                )}
+            />
+            <div className="font-medium text-indigo-600 pt-5 hover:text-indigo-500 focus:outline-none focus:underline transition ease-in-out duration-150">
+                <a href="/login">Login</a>
+            </div>
+        </AuthLayout>
+    );
 };
 
 export default RegisterForm;
-

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -8,8 +8,8 @@ render(
     <InertiaApp
         initialPage={JSON.parse(app!.dataset.page!)}
         resolveComponent={name =>
-			import(`./Pages/${name}`).then(module => module.default)
+            import(`./Pages/${name}`).then(module => module.default)
         }
     />,
-    app
+    app,
 );


### PR DESCRIPTION
This pull request adds the [Prettier](https://prettier.io/) code formatting tool. I've integrated it with eslint, so that when we run `npm run lint`, it runs prettier as well.

Prettier works with most popular code editors, it might be worth setting this up in your editor so that it will just run Prettier automatically when you save a file. There are some more details about how to set this up [here](https://prettier.io/docs/en/editors.html).

I've also added a basic GitHub action which will run the linter, once using node 10 and once using node 12. The results of these checks show up on all Pull Requests as green (if they pass) or red (if they fail), like this:

If the checks are successful:
![image](https://user-images.githubusercontent.com/12138621/81289803-eb772100-905e-11ea-9462-863b880b867e.png)

If some of the checks fail:
![image](https://user-images.githubusercontent.com/12138621/81290267-af908b80-905f-11ea-83ab-c0561c021d6d.png)
