### PR TITLE
Hide the My Account link for now, as we haven't finished building that page

### DIFF
--- a/resources/js/Layouts/AppLayout.tsx
+++ b/resources/js/Layouts/AppLayout.tsx
@@ -130,12 +130,6 @@ export const AppLayout: FC<Props> = ({
                                         >
                                             <div className="py-1 rounded-md bg-white shadow-xs">
                                                 <InertiaLink
-                                                    href={route("account.edit")}
-                                                    className="block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out"
-                                                >
-                                                    My Account
-                                                </InertiaLink>
-                                                <InertiaLink
                                                     method="DELETE"
                                                     href={route(
                                                         "auth.login.destroy",
@@ -233,12 +227,6 @@ export const AppLayout: FC<Props> = ({
                                 aria-orientation="vertical"
                                 aria-labelledby="user-menu"
                             >
-                                <InertiaLink
-                                    href={route("account.edit")}
-                                    className="block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 focus:outline-none focus:text-gray-800 focus:bg-gray-100 transition duration-150 ease-in-out"
-                                >
-                                    My Account
-                                </InertiaLink>
                                 <InertiaLink
                                     method="DELETE"
                                     href={route("auth.login.destroy")}


### PR DESCRIPTION
I haven't removed the page entirely - you can still access the page if you navigate to the URL `/account`. I've just hidden the link to that page from the nav menu on both the desktop and the mobile view.


This is what the nav menu looks like now:

On desktop:
![image](https://user-images.githubusercontent.com/12138621/93237884-9f5c8b80-f778-11ea-84b1-56e097d70359.png)

and on mobile:
![image](https://user-images.githubusercontent.com/12138621/93237748-6e7c5680-f778-11ea-8af8-bf5d6c84db44.png)
