### PR TITLE
Default new mentor/mentee profiles to confirmed instead of pending

### DIFF
--- a/app/Models/MentorProfile.php
+++ b/app/Models/MentorProfile.php
@@ -12,6 +12,7 @@ class MentorProfile extends Model
         'skillset',
         'suitable_time',
         'extra_info',
+        'status',
     ];
 
     public function user()

--- a/database/migrations/2020_06_16_215943_create_mentee_profiles_table.php
+++ b/database/migrations/2020_06_16_215943_create_mentee_profiles_table.php
@@ -25,7 +25,7 @@ class CreateMenteeProfilesTable extends Migration
             $table->text('timeframe')->nullable();
             $table->text('suitable_time')->nullable();
             $table->text('extra_info')->nullable();
-            $table->tinyInteger('status')->unsigned()->default(ProfileStatus::Pending);
+            $table->tinyInteger('status')->unsigned()->default(ProfileStatus::Confirmed);
             $table->unsignedBigInteger('user_id')->nullable();
             $table->foreign('user_id')->references('id')->on('users');
         });

--- a/database/migrations/2020_07_05_030115_create_mentor_profiles_table.php
+++ b/database/migrations/2020_07_05_030115_create_mentor_profiles_table.php
@@ -21,7 +21,7 @@ class CreateMentorProfilesTable extends Migration
             $table->text('skillset')->nullable();
             $table->text('suitable_time')->nullable();
             $table->text('extra_info')->nullable();
-            $table->tinyInteger('status')->unsigned()->default(ProfileStatus::Pending);
+            $table->tinyInteger('status')->unsigned()->default(ProfileStatus::Confirmed);
             $table->unsignedBigInteger('user_id')->nullable();
             $table->foreign('user_id')->references('id')->on('users');
             $table->timestamps();


### PR DESCRIPTION
As discussed in the meeting 4 weeks ago, we want to default all new mentor & mentee signups to the "Confirmed" status rather than the "Pending" status for now.

In future we might want to introduce a manual step for admin users to confirm new mentor/mentee signups, but we aren't doing that yet.